### PR TITLE
Update LLVM lib/Demangle 0cc19b564dd3a2b7ce51840d6...2dea832ef064bb86

### DIFF
--- a/third_party/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/third_party/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -2336,7 +2336,7 @@ public:
         Float value;
         char buf[sizeof(Float)];
       };
-      const char *t = &*Contents.begin();
+      const char *t = Contents.data();
       const char *last = t + N;
       char *e = buf;
       for (; t != last; ++t, ++e) {
@@ -3714,8 +3714,7 @@ Node *AbstractManglingParser<Derived, Alloc>::parseQualifiedType() {
       std::string_view ProtoSourceName(Qual.data() + Len, Qual.size() - Len);
       std::string_view Proto;
       {
-        ScopedOverride<const char *> SaveFirst(First,
-                                               &*ProtoSourceName.begin()),
+        ScopedOverride<const char *> SaveFirst(First, ProtoSourceName.data()),
             SaveLast(Last, &*ProtoSourceName.rbegin() + 1);
         Proto = parseBareSourceName();
       }

--- a/third_party/llvm/lib/Demangle/ItaniumDemangle.cpp
+++ b/third_party/llvm/lib/Demangle/ItaniumDemangle.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <functional>
 #include <utility>
 
@@ -79,7 +80,7 @@ struct DumpVisitor {
 
   void printStr(const char *S) { fprintf(stderr, "%s", S); }
   void print(std::string_view SV) {
-    fprintf(stderr, "\"%.*s\"", (int)SV.size(), &*SV.begin());
+    fprintf(stderr, "\"%.*s\"", (int)SV.size(), SV.data());
   }
   void print(const Node *N) {
     if (N)

--- a/third_party/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/third_party/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -268,7 +268,7 @@ std::string_view Demangler::copyString(std::string_view Borrowed) {
   // This is not a micro-optimization, it avoids UB, should Borrowed be an null
   // buffer.
   if (Borrowed.size())
-    std::memcpy(Stable, &*Borrowed.begin(), Borrowed.size());
+    std::memcpy(Stable, Borrowed.data(), Borrowed.size());
 
   return {Stable, Borrowed.size()};
 }
@@ -792,7 +792,7 @@ SymbolNode *Demangler::demangleMD5Name(std::string_view &MangledName) {
     Error = true;
     return nullptr;
   }
-  const char *Start = &*MangledName.begin();
+  const char *Start = MangledName.data();
   const size_t StartSize = MangledName.size();
   MangledName.remove_prefix(MD5Last + 1);
 
@@ -2382,7 +2382,7 @@ void Demangler::dumpBackReferences() {
     T->output(OB, OF_Default);
 
     std::string_view B = OB;
-    std::printf("  [%d] - %.*s\n", (int)I, (int)B.size(), &*B.begin());
+    std::printf("  [%d] - %.*s\n", (int)I, (int)B.size(), B.data());
   }
   std::free(OB.getBuffer());
 
@@ -2391,7 +2391,7 @@ void Demangler::dumpBackReferences() {
   std::printf("%d name backreferences\n", (int)Backrefs.NamesCount);
   for (size_t I = 0; I < Backrefs.NamesCount; ++I) {
     std::printf("  [%d] - %.*s\n", (int)I, (int)Backrefs.Names[I]->Name.size(),
-                &*Backrefs.Names[I]->Name.begin());
+                Backrefs.Names[I]->Name.data());
   }
   if (Backrefs.NamesCount > 0)
     std::printf("\n");
@@ -2404,7 +2404,7 @@ char *llvm::microsoftDemangle(std::string_view MangledName, size_t *NMangled,
   std::string_view Name{MangledName};
   SymbolNode *AST = D.parse(Name);
   if (!D.Error && NMangled)
-    *NMangled = Name.empty() ? MangledName.size() : &*Name.begin() - &*MangledName.begin();
+    *NMangled = MangledName.size() - Name.size();
 
   if (Flags & MSDF_DumpBackrefs)
     D.dumpBackReferences();


### PR DESCRIPTION
This removes the downstream patch I added in https://github.com/nico/demumble/commit/b6d584c63ed9da4bbe7c7b14636a13718ecd49d1,
https://github.com/llvm/llvm-project/issues/63740 is now fixed upstream.

Ran:

    cp ~/src/llvm-project/llvm/include/llvm/Demangle/*.{h,def} third_party/llvm/include/llvm/Demangle/
    cp ~/src/llvm-project/llvm/lib/Demangle/*.cpp third_party/llvm/lib/Demangle/
    cp ~/src/llvm-project/llvm/LICENSE.TXT third_party/llvm/LICENSE.txt