### PR TITLE
github actions: don't explicitly install gcc 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: "Install Ubuntu dependencies"
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-12 g++-12 libstdc++-12-dev ninja-build
+        sudo apt-get install -y ninja-build
 
     - name: CMake
       run: |


### PR DESCRIPTION
Per https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#language-and-runtime gcc-12 is already part of the image.

Thanks to @ADKaster for pointing this out!