### PR TITLE
github actions: Explicitly pass `.` to cmake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: CMake
       run: |
-        cmake -GNinja
+        cmake -GNinja .
 
     - name: Build
       run: |


### PR DESCRIPTION
Trying to fix:

    CMake Warning:
      No source or binary directory provided.  Both will be assumed to be the
      same as the current working directory, but note that this warning will
      become a fatal error in future CMake releases.