### PR TITLE
github actions: Use setup-ninja instead of apt for installing ninja

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: "Install Ubuntu dependencies"
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ninja-build
+    - name: Set up Ninja
+      uses: ashutoshvarma/setup-ninja@v1.1
 
     - name: CMake
       run: |


### PR DESCRIPTION
This will work on other host OSs. Also, `apt-get update`, while cool, takes pretty long to run.

(On the downside, this misprints "Received" in the log, and upstream seems to have stopped acception PRs, ah well.)