### PR TITLE
github actions: Actually run tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
 
     - name: Test
       run: |
-        ./demumble_test.py 
+        python3 demumble_test.py


### PR DESCRIPTION
Verified it works now by pushing a commit that adds

    print('os name:', os.name, sys.version)
    if os.name == 'nt':
        tests += [('demumble _Z4funcPci _Z1fv', 'fnc(char*, int)\nf()\n')]

to demumble_test.py on a test branch and checking that CI now fails on Windows, while it didn't' before.

Also, the 'passed' output now shows up.

(Just `python` instead of `python3` also runs Python 3.11 on all the github action images demumble currently uses, and normally python is called just `python` on Windows, not `python3`. But `python3` seems to work on GitHub actions, so let's be explicit about it.)