### PR TITLE
ci: don't run CI twice for my own pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Build and test
 
-on: [push, pull_request]
+on: {push: { branches: [main] }, pull_request: {}}
 
 jobs:
   build:


### PR DESCRIPTION
`on: [push, pull_request]` has the effect that CI runs twice if I push to a feature branch in my repo and then make a pull request – once for the push to the feature branch, and once for the PR.

Instead, only run CI on pushes to the main branch (and on all PRs).