### PR TITLE
add install rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,3 +67,8 @@ add_executable(demumble
 )
 set_target_properties(demumble PROPERTIES CXX_STANDARD 17
                                           CXX_STANDARD_REQUIRED ON)
+install(TARGETS demumble
+        CONFIGURATIONS Release
+        RUNTIME
+          DESTINATION bin
+)


### PR DESCRIPTION
This PR makes us to be able to install `demumble` with `cmake --install`:

```console
$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/path/to -GNinja .
$ cmake --build .
$ cmake --install .      # This PR makes this line available
$ /path/to/bin/demumble --help
```